### PR TITLE
Fix building and passing tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/xaionaro-go/logrustash
+
+go 1.22
+
+require github.com/sirupsen/logrus v1.9.3
+
+require (
+	github.com/xaionaro-go/goautosocket v0.0.0-20240803221104-cef7f165571a
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/xaionaro-go/goautosocket v0.0.0-20240803221104-cef7f165571a h1:nnSVcn4e9TkQ5GuN/MoeET18gSYudJJMtlKXFRHvVjQ=
+github.com/xaionaro-go/goautosocket v0.0.0-20240803221104-cef7f165571a/go.mod h1:7X2d4ohzI2SqqM/dNgIlBx3hUl6dB6clspwt+9c9IqA=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/logstash.go
+++ b/logstash.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"github.com/teh-cmc/goautosocket"
+	gas "github.com/xaionaro-go/goautosocket"
 )
 
 // Hook represents a connection to a Logstash instance
@@ -73,7 +73,16 @@ func NewAsyncHookWithFields(protocol, address, appName string, alwaysSentFields 
 // NewHookWithFieldsAndPrefix creates a new hook to a Logstash instance, which listens on
 // `protocol`://`address`. alwaysSentFields will be sent with every log entry. prefix is used to select fields to filter.
 func NewHookWithFieldsAndPrefix(protocol, address, appName string, alwaysSentFields logrus.Fields, prefix string) (*Hook, error) {
-	conn, err := gas.Dial(protocol, address)
+	var (
+		conn net.Conn
+		err  error
+	)
+	switch protocol {
+	case "tcp":
+		conn, err = gas.Dial("tcp", address)
+	default:
+		conn, err = net.Dial(protocol, address)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +119,7 @@ func NewAsyncHookWithFieldsAndConn(conn net.Conn, appName string, alwaysSentFiel
 	return NewAsyncHookWithFieldsAndConnAndPrefix(conn, appName, alwaysSentFields, "")
 }
 
-//NewHookWithFieldsAndConnAndPrefix creates a new hook to a Logstash instance using the suppolied connection and prefix.
+// NewHookWithFieldsAndConnAndPrefix creates a new hook to a Logstash instance using the suppolied connection and prefix.
 func NewHookWithFieldsAndConnAndPrefix(conn net.Conn, appName string, alwaysSentFields logrus.Fields, prefix string) (*Hook, error) {
 	return &Hook{conn: conn, appName: appName, alwaysSentFields: alwaysSentFields, hookOnlyPrefix: prefix}, nil
 }
@@ -172,12 +181,12 @@ func (h *Hook) filterHookOnly(entry *logrus.Entry) {
 
 }
 
-//WithPrefix sets a prefix filter to use in all subsequent logging
+// WithPrefix sets a prefix filter to use in all subsequent logging
 func (h *Hook) WithPrefix(prefix string) {
 	h.hookOnlyPrefix = prefix
 }
 
-//WithField add field with value that will be sent with each message
+// WithField add field with value that will be sent with each message
 func (h *Hook) WithField(key string, value interface{}) {
 	h.alwaysSentFields[key] = value
 }

--- a/logstash_formatter_test.go
+++ b/logstash_formatter_test.go
@@ -47,7 +47,7 @@ func TestLogstashFormatter(t *testing.T) {
 		{"abc", "type"},
 		{"msg", "message"},
 		{"info", "level"},
-		{"Get http://example.com: The error", "error"},
+		{`Get "http://example.com": The error`, "error"},
 		// substituted fields
 		{"def", "fields.message"},
 		{"ijk", "fields.level"},


### PR DESCRIPTION
# Before
```
xaionaro@void:~/go/src/github.com/xaionaro-go/logrustash$ go test ./... -test.count=1
pattern ./...: directory prefix . does not contain main module or its selected dependencies
xaionaro@void:~/go/src/github.com/xaionaro-go/logrustash$ go mod init
go: creating new go.mod: module github.com/xaionaro-go/logrustash
go: to add module requirements and sums:
	go mod tidy
xaionaro@void:~/go/src/github.com/xaionaro-go/logrustash$ go mod tidy
go: finding module for package github.com/sirupsen/logrus
go: finding module for package github.com/teh-cmc/goautosocket
go: found github.com/sirupsen/logrus in github.com/sirupsen/logrus v1.9.3
go: finding module for package github.com/teh-cmc/goautosocket
go: github.com/xaionaro-go/logrustash imports
	github.com/teh-cmc/goautosocket: cannot find module providing package github.com/teh-cmc/goautosocket: module github.com/teh-cmc/goautosocket: git ls-remote -q origin in /home/xaionaro/.gvm/pkgsets/go1.22.1/global/pkg/mod/cache/vcs/9b99942761a13c552cfdbd0877837e4cec83bdc7a231c9c0224ba501b36d1e77: exit status 128:
	fatal: could not read Username for 'https://github.com': terminal prompts disabled
Confirm the import path was entered correctly.
If this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
xaionaro@void:~/go/src/github.com/xaionaro-go/logrustash$ sed -e 's/teh-cmc/netbrain/g' -i logstash.go
xaionaro@void:~/go/src/github.com/xaionaro-go/logrustash$ go mod tidy
go: finding module for package github.com/sirupsen/logrus
go: finding module for package github.com/netbrain/goautosocket
go: found github.com/netbrain/goautosocket in github.com/netbrain/goautosocket v0.0.0-20150624145746-bef85f0aef40
go: found github.com/sirupsen/logrus in github.com/sirupsen/logrus v1.9.3
xaionaro@void:~/go/src/github.com/xaionaro-go/logrustash$ go test ./... -test.count=1
--- FAIL: TestLogstashFormatter (0.00s)
    logstash_formatter_test.go:58: expected data[error] to be 'Get http://example.com: The error' but got 'Get "http://example.com": The error'
--- FAIL: TestLogstashHook (0.00s)
    logstash_test.go:90: unknown network udp
    logstash_test.go:93: expected hook to be not nil
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x570f3a]

goroutine 7 [running]:
testing.tRunner.func1.2({0x592f80, 0x711f40})
	/home/xaionaro/.gvm/gos/go1.22.1/src/testing/testing.go:1631 +0x24a
testing.tRunner.func1()
	/home/xaionaro/.gvm/gos/go1.22.1/src/testing/testing.go:1634 +0x377
panic({0x592f80?, 0x711f40?})
	/home/xaionaro/.gvm/gos/go1.22.1/src/runtime/panic.go:770 +0x132
github.com/xaionaro-go/logrustash.TestLogstashHook(0xc0000d0680)
	/home/xaionaro/go/src/github.com/xaionaro-go/logrustash/logstash_test.go:96 +0x55a
testing.tRunner(0xc0000d0680, 0x5d0e90)
	/home/xaionaro/.gvm/gos/go1.22.1/src/testing/testing.go:1689 +0xfb
created by testing.(*T).Run in goroutine 1
	/home/xaionaro/.gvm/gos/go1.22.1/src/testing/testing.go:1742 +0x390
FAIL	github.com/xaionaro-go/logrustash	0.006s
FAIL
```

# After
```
xaionaro@void:~/go/src/github.com/xaionaro-go/logrustash$ go test ./... -test.count=1
ok  	github.com/xaionaro-go/logrustash	0.005s
```